### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/invite-trigger.yaml
+++ b/.github/workflows/invite-trigger.yaml
@@ -1,4 +1,6 @@
 name: "Invite: Trigger"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/PRODYNA-YASM/.github/security/code-scanning/2](https://github.com/PRODYNA-YASM/.github/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow at the top level, immediately after the `name:` key and before the `on:` key. As a minimal starting point, set `contents: read` (the most restrictive common permission) unless you know more specific permissions are needed by the called workflow. Setting the `permissions` block at the root level applies these permissions to all jobs that do not have their own `permissions` key, including the single `call-invite` job in this workflow. This change does not affect existing functionality, but significantly improves security posture by restricting the default permissions of the GITHUB_TOKEN as recommended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
