### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/overview-trigger.yaml
+++ b/.github/workflows/overview-trigger.yaml
@@ -1,4 +1,6 @@
 name: "Deployment Overview: Trigger"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/PRODYNA-YASM/.github/security/code-scanning/1](https://github.com/PRODYNA-YASM/.github/security/code-scanning/1)

To address the issue, add a `permissions` block to the workflow, specifying the minimal token access needed. Since the workflow simply calls a reusable workflow and passes a secret, it should default to the least privilege, which is typically `contents: read`, unless more is required. Place the `permissions:` block at the root level (before `jobs:`) to give all jobs these minimal permissions unless overridden. If future jobs need more permission, their job-level `permissions:` can be elevated locally.  

Edit `.github/workflows/overview-trigger.yaml`, inserting the following after the `name:` line (suggested minimal starting point):  
```yaml
permissions:
  contents: read
```
This ensures the workflow no longer runs with unspecified (potentially write) privileges.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
